### PR TITLE
コマンドラインツールとしての設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # swimmy
 Command and Control Server Sample
 
+## Install
+```bash
+$ pip install git+https://github.com/kiyoto1022/swimmy.git
+```
+
 ## Start C&C Server
 ### 1. Execute
 ```
-$ python swimmy.py
+$ swimmy
 
 ███████╗██╗    ██╗██╗███╗   ███╗███╗   ███╗██╗   ██╗
 ██╔════╝██║    ██║██║████╗ ████║████╗ ████║╚██╗ ██╔╝

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+setup(
+    name="swimmy",
+    version="0.0.1",
+    description="Command and Control Server Sample",
+    license="",
+    author="",
+    packages=[],
+    install_requires=[],
+    long_description="",
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+    ],
+    entry_points={
+        'console_scripts': ['swimmy=swimmy:main'],
+    }
+)

--- a/swimmy.py
+++ b/swimmy.py
@@ -8,5 +8,9 @@ class Swimmy(Console):
         self.cmdloop()
 
 
-if __name__ == '__main__':
+def main():
     Swimmy().start()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
pip は git の URL指定でインストールすることができるらしいです。はー便利。
パッケージ構成などは変更せず、 `setup.py` を追加してインストールできるようにしました。

license とか author とか空文字にしてます 🙏 